### PR TITLE
new: add prepublishOnly script for better publish practises

### DIFF
--- a/README.md
+++ b/README.md
@@ -1053,6 +1053,47 @@ maticPOSClient.exitERC20('0xabcd...789', {
 
 ---
 
+### Development
+
+**Setup**
+
+```bash
+npm install
+```
+
+**Lint**
+
+```bash
+# To check lint errors
+npm run lint
+
+# To fix most common lint errors
+# Note that it might not fix all errors, some need manual intervention
+npm run lint:fix
+```
+
+**Transpile typescript files**
+
+```bash
+npm run build
+```
+
+**Generate distribution files**
+
+```bash
+npm run build:webpack
+```
+
+**NPM publish**
+
+Before running publish script, make sure you have updated version properly.
+
+Note that `prepublishOnly` script will be automatically called while publishing. It will check lint, clean dist/lib folders and build fresh distribution files before it executes `npm publish`.
+
+```bash
+npm publish
+```
+
 ### License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "clean": "rimraf lib dist",
     "build:webpack": "webpack --env build",
     "build": "tsc",
+    "prepublishOnly": "npm run lint && npm run clean && npm run build && npm run build:webpack",
     "lint": "eslint --ext .ts src",
     "lint:fix": "eslint --ext .ts src --fix",
     "test": "mocha --require @babel/register --colors ./test/**/*.spec.js",


### PR DESCRIPTION
Adds `prepublishOnly` script. It is automatically called before publishing the new npm package version. This will force fresh build and enforces better publish practices. 