### PR TITLE
Add MIT attribution for proof_util.ts

### DIFF
--- a/src/utils/proof_util.ts
+++ b/src/utils/proof_util.ts
@@ -8,6 +8,8 @@ const rlp = ethUtils.rlp;
 import EthereumBlock from 'ethereumjs-block/from-rpc';
 import { Converter, promiseResolve, utils } from "..";
 
+// Implementation adapted from Tom French's `matic-proofs` library used under MIT License
+// https://github.com/TomAFrench/matic-proofs
 
 export class ProofUtil {
 


### PR DESCRIPTION
I've added attribution for `getFastMerkleProof` as taken from https://github.com/TomAFrench/matic-proofs/blob/master/src/utils/fastMerkle.ts

I'd also recommend adding back in my optimisation to calculate each hash in parallel and resolving all promises at the end of the function rather than waiting for a response from the node before querying the next.