### PR TITLE
add withdrawWithMetadaExit in erc721pos

### DIFF
--- a/src/enums/log_event_signature.ts
+++ b/src/enums/log_event_signature.ts
@@ -6,5 +6,6 @@ export enum Log_Event_Signature {
     Erc1155Transfer = '0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62',
     Erc721BatchTransfer = '0xf871896b17e9cb7a64941c62c188a4f5c621b86800e3d15452ece01ce56073df',
     Erc1155BatchTransfer = '0x4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb',
+    Erc721TransferWithMetadata = '0xf94915c6d1fd521cee85359239227480c7e8776d7caf1fc3bacad5c269b66a14',
 
 }

--- a/src/pos/erc721.ts
+++ b/src/pos/erc721.ts
@@ -247,6 +247,21 @@ export class ERC721 extends POSToken {
         });
     }
 
+    withdrawExitWithMetadata(burnTransactionHash: string, option?: ITransactionOption) {
+        this.checkForRoot("withdrawExitWithMetadata");
+
+
+        return this.exitUtil.buildPayloadForExit(
+            burnTransactionHash,
+            Log_Event_Signature.Erc721TransferWithMetadata,
+            false
+        ).then(payload => {
+            return this.rootChainManager.exit(
+                payload, option
+            );
+        });
+    }
+
     withdrawExitMany(burnTransactionHash: string, option?: ITransactionOption) {
         this.checkForRoot("withdrawExitMany");
 
@@ -295,6 +310,12 @@ export class ERC721 extends POSToken {
     isWithdrawExited(txHash: string) {
         return this.isWithdrawn(
             txHash, Log_Event_Signature.Erc721Transfer
+        );
+    }
+
+    isWithdrawWithMetadaExited(txHash: string) {
+        return this.isWithdrawn(
+            txHash, Log_Event_Signature.Erc721TransferWithMetadata
         );
     }
 


### PR DESCRIPTION
Hi !
I came across the limitation where i wanted to finalise my exit from L2 to L1 with the token's metadata. 
Weirdly it is not implemented yet. I thought it would be an important feature to have.... 
Anyway, here it is.