### PR TITLE
Added missing parameter for depositEther function example

### DIFF
--- a/content/docs/pos/deposit-ether.md
+++ b/content/docs/pos/deposit-ether.md
@@ -9,7 +9,7 @@ Description: 'depositEther method can be used to deposit required amount of ethe
 `depositEther` method can be used to deposit required amount of **ether** from ethereum to polygon.
 
 ```
-const result = await posClient.depositEther(<amount>);
+const result = await posClient.depositEther(<amount>, <userAddress>);
 
 const txHash = await result.getTransactionHash();
 


### PR DESCRIPTION
The userAddress parameter was omitted from the signature of the depositEther method in the documentation: https://maticnetwork.github.io/matic.js/docs/pos/deposit-ether/

If used without this parameter an error like this occurs:
invalid address (argument="address", value=undefined, code=INVALID_ARGUMENT, version=address/5.5.0) (argument="user", value=undefined, code=INVALID_ARGUMENT, version=abi/5.0.7)

Source code reference: https://github.com/maticnetwork/matic.js/blob/4dfae5d06a50c365baaaafcdcea7c770b67f18ef/src/pos/index.ts#L79