### PR TITLE
UD resolution support

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -22,5 +22,6 @@ export * from "./not_implemented";
 export const utils = {
     converter: Converter,
     Web3Client: BaseWeb3Client,
-    BN: EmptyBigNumber
+    BN: EmptyBigNumber,
+    UnstoppableDomains: Object
 };

--- a/src/utils/web3_side_chain_client.ts
+++ b/src/utils/web3_side_chain_client.ts
@@ -13,6 +13,7 @@ export class Web3SideChainClient<T_CONFIG> {
     abiManager: ABIManager;
 
     logger = new Logger();
+    resolution: {};
 
     init(config: IBaseClientConfig) {
         config = config || {} as any;
@@ -25,6 +26,10 @@ export class Web3SideChainClient<T_CONFIG> {
 
         if (!Web3Client) {
             throw new Error("Web3Client is not set");
+        }
+
+        if (utils.UnstoppableDomains) {
+            this.resolution = utils.UnstoppableDomains;
         }
 
         this.parent = new (Web3Client as any)(config.parent.provider, this.logger);


### PR DESCRIPTION
This PR adds the UD domain resolution plugin into the matic.js `utils` namespace so that it can be called using the same syntax as web3.js and ethers.js. Eg:

```js
const addr = client.resolution.addr('brad.crypto', 'ETH')
```

If a client application does not use the UD plugin the name will be undefined and no additional dependencies will be involved. It changes 5 source lines code without impact on lib size. 