### PR TITLE
added unstoppable domains setup guide

### DIFF
--- a/content/docs/fx-portal.md
+++ b/content/docs/fx-portal.md
@@ -10,6 +10,6 @@ FxPortal Bridge is similar to POS Bridge with a feature of using ERC standardize
 
 For more info about FxPortal, please read - [FxPortal Bridge doc](https://docs.polygon.technology/docs/develop/l1-l2-communication/fx-portal)
 
-FxPortal bridge functionality is available in [seperate repository](https://github.com/fx-portal/maticjs-fxportal) as a plugin for maticjs. The package provides different API's for interacting with bridge.
+FxPortal bridge functionality is available in [separate repository](https://github.com/fx-portal/maticjs-fxportal) as a plugin for maticjs. The package provides different API's for interacting with bridge.
 
 Here is repository link - [https://github.com/fx-portal/maticjs-fxportal](https://github.com/fx-portal/maticjs-fxportal)

--- a/content/docs/index.js
+++ b/content/docs/index.js
@@ -20,6 +20,10 @@ module.exports = [
         text: 'Ethers',
         url: 'ethers',
       },
+      {
+        text: 'Unstoppable Domains',
+        url: 'unstoppable-domains',
+      },
     ],
   },
   {

--- a/content/docs/plasma/index.md
+++ b/content/docs/plasma/index.md
@@ -6,7 +6,7 @@ Description: 'PlasmaClient allows you to interact with POS Bridge.'
 
 # Plasma Bridge
 
-Plasma bridge functionality is available in [seperate repository](https://github.com/maticnetwork/maticjs-plasma). So in order to use `plasma` bridge, you need to install seperate package.
+Plasma bridge functionality is available in [separate repository](https://github.com/maticnetwork/maticjs-plasma). So in order to use `plasma` bridge, you need to install separate package.
 
 ## Installation
 

--- a/content/docs/setup/ethers.md
+++ b/content/docs/setup/ethers.md
@@ -1,5 +1,5 @@
 ---
-Title: 'Web3js setup'
+Title: 'Ethers setup'
 Keywords: 'pos client, erc20, withdrawExit, polygon, sdk'
 Description: 'Get started with maticjs'
 ---
@@ -10,7 +10,7 @@ The [ethers.js](https://docs.ethers.io/) library aims to be a complete and compa
 
 ## Setup ether.js
 
-ether.js support is available via seperate package as a plugin for matic.js.
+ether.js support is available via a separate package as a plugin for matic.js.
 
 ### Installation
 

--- a/content/docs/setup/index.md
+++ b/content/docs/setup/index.md
@@ -8,7 +8,8 @@ Description: 'Get started with maticjs'
 
 In order to support multiple web3 libraries - maticjs provides plugins.
 
-Currently two libraries are supported -
+Currently three libraries are supported -
 
 1. Web3.js
 2. Ethers
+3. Unstoppable Domains

--- a/content/docs/setup/index.md
+++ b/content/docs/setup/index.md
@@ -8,8 +8,9 @@ Description: 'Get started with maticjs'
 
 In order to support multiple web3 libraries - maticjs provides plugins.
 
-Currently three libraries are supported -
+Currently two libraries are supported -
 
 1. Web3.js
 2. Ethers
-3. Unstoppable Domains
+
+> You can also use the [Unstoppable Domains resolution plugin](https://github.com/unstoppabledomains/maticjs-resolution) from the maticjs `utils` namespace.

--- a/content/docs/setup/unstoppable-domains.md
+++ b/content/docs/setup/unstoppable-domains.md
@@ -1,0 +1,77 @@
+---
+Title: 'Unstoppable Domains setup'
+Keywords: 'pos client, erc20, withdrawExit, polygon, sdk'
+Description: 'Get started with maticjs'
+---
+
+# Unstoppable Domains
+
+The [unstoppable domains](https://github.com/unstoppabledomains/resolution) library aims to be a complete and compact library for interacting with NFT domain names. You can use them to retrieve [payment addresses](https://docs.unstoppabledomains.com/crypto-payments/), IPFS hashes for [decentralized websites](https://docs.unstoppabledomains.com/d-websites/), DNS records, and other [records types](https://docs.unstoppabledomains.com/getting-started/domain-registry-essentials/records-reference/).
+
+## Setup Unstoppable Domains
+
+Unstoppable Domains support is available via a separate package as a plugin for matic.js.
+
+### Installation
+
+```
+npm install @unstoppabledomains/maticjs-resolution
+```
+
+### setup
+
+```
+import { use } from '@maticnetwork/maticjs'
+import { UnstoppableDomainsClientPlugin } from '@unstoppabledomains/maticjs-resolution'
+
+// install unstoppable domains plugin
+use(UnstoppableDomainsClientPlugin)
+```
+
+Let's see one example of resolving wallet address, domain records, and IPFS hash using unstoppable domains -
+
+```
+import HDWalletProvider from "@truffle/hdwallet-provider"
+import { POSClient,use } from "@maticnetwork/maticjs"
+import { Web3ClientPlugin } from '@maticnetwork/maticjs-web3'
+import { UnstoppableDomainsClientPlugin } from '@unstoppabledomains/maticjs-resolution'
+
+// install unstoppable domains plugin
+use(Web3ClientPlugin);
+use(UnstoppableDomainsClientPlugin);
+
+const posClient = new POSClient();
+await posClient.init({
+    network: 'testnet',
+    version: 'mumbai',
+    parent: {
+      provider: new HDWalletProvider(privateKey, mainRPC),
+      defaultConfig: {
+        from : fromAddress
+      }
+    },
+    child: {
+      provider: new HDWalletProvider(privateKey, childRPC),
+      defaultConfig: {
+        from : fromAddress
+      }
+    }
+});
+const client = posClient.client;
+
+// Resolve a token address from a domain
+const addr = await client.resolution.addr('brad.crypto', 'ETH');
+console.log(`Ethereum address for brad.crypto is ${addr}`);
+
+// Resolve all records from a domain
+const records = await client.resolution.allRecords('brad.crypto');
+console.log(`All records for brad.crypto are ${JSON.stringify(records)}`);
+
+// Resolve an ipfs hash from a domain
+const ipfsHash = await client.resolution.ipfsHash('homecakes.crypto');
+console.log(`IPFS hash for homecakes.crypto is ${ipfsHash}`);
+```
+
+## Examples
+
+The examples for different cases are available on [unstoppable domains plugin repo](https://github.com/unstoppabledomains/maticjs-resolution).

--- a/content/docs/setup/web3js.md
+++ b/content/docs/setup/web3js.md
@@ -10,7 +10,7 @@ Description: 'Get started with maticjs'
 
 ## Setup web3.js
 
-web3.js support is available via seperate package as a plugin for matic.js.
+web3.js support is available via a separate package as a plugin for matic.js.
 
 ### Installation
 


### PR DESCRIPTION
The [Unstoppable Domains resolution plugin](https://github.com/unstoppabledomains/maticjs-resolution) became integrated into the matic.js library from [version 3.2.5](https://github.com/maticnetwork/matic.js/pull/331). This PR contains an update on the documentation of these changes.

* mentioning the integration on the [setup page](https://maticnetwork.github.io/matic.js/docs/setup/)
* adding a guide on the unstoppable domains plugin containing installation steps, setup guide, and example code
* some typo fixes