### PR TITLE
fix(proof_util): make requestConcurrency effective and retry transient network errors

### DIFF
--- a/src/utils/proof_util.ts
+++ b/src/utils/proof_util.ts
@@ -123,20 +123,54 @@ export class ProofUtil {
         const receiptsTrie = new TRIE();
         let receiptPromise: Promise<ITransactionReceipt[]>;
         if (!receiptsVal) {
-            const receiptPromises = [];
+            // Collect tx hashes without starting requests yet, so that mapPromise
+            // can enforce requestConcurrency as an actual HTTP concurrency limit.
+            // Previously, all getTransactionReceipt calls were started eagerly
+            // inside the forEach before mapPromise was called, making
+            // requestConcurrency a no-op: all requests fired simultaneously
+            // regardless of the setting.
+            const txHashes: string[] = [];
             block.transactions.forEach(tx => {
                 if (tx.transactionHash === stateSyncTxHash) {
                     // ignore if tx hash is bor state-sync tx
                     return;
                 }
-                receiptPromises.push(
-                    web3.getTransactionReceipt(tx.transactionHash)
-                );
+                txHashes.push(tx.transactionHash);
             });
             receiptPromise = mapPromise(
-                receiptPromises,
-                val => {
-                    return val;
+                txHashes,
+                (hash: string) => {
+                    // Retry transient network errors so that a single stale
+                    // keep-alive socket or a brief DNS hiccup does not fail the
+                    // entire proof.  Node.js 19+ enables keep-alive on the
+                    // global HTTPS agent by default; if the server closes an
+                    // idle connection while sequential Ethereum RPC calls are
+                    // running, the next Polygon receipt fetch hits the stale
+                    // socket and receives ECONNRESET.
+                    //
+                    // Each retry waits a full-jitter exponential backoff delay
+                    // in [0, min(2000ms, 250ms * 2^i)] before re-attempting,
+                    // so that a burst of simultaneous failures does not hammer
+                    // the RPC endpoint with synchronised retries.
+                    const MAX_RETRIES = 2;
+                    const attempt = (remaining: number): Promise<ITransactionReceipt> =>
+                        web3.getTransactionReceipt(hash).catch((err: any) => {
+                            const isTransient =
+                                err?.code === 'ECONNRESET'   ||
+                                err?.code === 'ENOTFOUND'    ||
+                                err?.code === 'ECONNREFUSED' ||
+                                err?.code === 'ETIMEDOUT'    ||
+                                err?.errno === 'ECONNRESET'  ||
+                                err?.errno === 'ENOTFOUND';
+                            if (remaining > 0 && isTransient) {
+                                const i = MAX_RETRIES - remaining;
+                                const delayMs = Math.random() * Math.min(250, 50 * Math.pow(2, i));
+                                return new Promise<void>(resolve => setTimeout(resolve, delayMs))
+                                    .then(() => attempt(remaining - 1));
+                            }
+                            throw err;
+                        });
+                    return attempt(MAX_RETRIES);
                 },
                 {
                     concurrency: requestConcurrency,

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -5,7 +5,12 @@ module.exports = {
     testEnvironment: 'node',
     testRegex: 'specs/index.ts',
     moduleFileExtensions: ['ts', 'js'],
-    "testPathIgnorePatterns": [
-        "<rootDir>/(build|bin|dist|node_modules)/"
-    ]
+    testPathIgnorePatterns: [
+        '<rootDir>/(build|bin|dist|node_modules)/'
+    ],
+    // src/utils/http_request.ts branches on BUILD_ENV to pick node-fetch over
+    // window.fetch; without this the test runner throws "window is not defined".
+    testEnvironmentOptions: {
+        env: { BUILD_ENV: 'node' }
+    },
 };

--- a/test/package.json
+++ b/test/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.spec.js",
   "scripts": {
+    "test": "BUILD_ENV=node jest",
     "link:lib": "npm link @maticnetwork/maticjs",
     "debug": "node debug.js",
     "link:lib:debug": "npm run link:lib && npm run debug"

--- a/test/specs/index.ts
+++ b/test/specs/index.ts
@@ -1,0 +1,186 @@
+/**
+ * Unit tests for the two bugs fixed in ProofUtil.getReceiptProof
+ *
+ * Background
+ * ----------
+ * getReceiptProof must fetch a receipt for every transaction in a Polygon block
+ * in order to rebuild the receipts trie and produce an inclusion proof.  Blocks
+ * on Polygon mainnet can contain 280+ transactions.
+ *
+ * Bug 1 — requestConcurrency had no effect on HTTP concurrency
+ *   The original code called web3.getTransactionReceipt() inside a forEach
+ *   loop and pushed the *already-running* Promises into an array, then passed
+ *   that array to mapPromise.  Because every request was already in-flight by
+ *   the time mapPromise saw the array, mapPromise's `concurrency` option only
+ *   controlled result-collection batching; it had zero effect on how many HTTP
+ *   requests were made simultaneously.  Setting requestConcurrency: 10 in the
+ *   caller (proof-generation-api) therefore did nothing.
+ *
+ * Bug 2 — transient network errors (ECONNRESET, ENOTFOUND, …) were not retried
+ *   Node.js 19+ enables keep-alive on the global HTTPS agent by default.
+ *   ethers.js v5 uses that agent (no custom agent is passed to https.request).
+ *   During proof generation several Polygon RPC calls run early (isCheckPointed,
+ *   getBlockWithTransaction, getFastMerkleProof), then sequential Ethereum calls
+ *   run for a few seconds.  During that idle window the RPC server can close
+ *   pooled keep-alive connections.  When getReceiptProof then fires 280+
+ *   requests, some hit stale sockets and receive ECONNRESET.  Because neither
+ *   mapPromise nor the converter had any retry logic, a single failure propagated
+ *   immediately through Promise.all and the whole proof attempt failed.
+ *
+ * The fix (src/utils/proof_util.ts)
+ *   - Collects tx hashes first, then passes a *factory* function to mapPromise
+ *     so requests are started lazily inside mapPromise under its concurrency
+ *     control.
+ *   - The factory wraps each call with up to 2 retries for transient errors.
+ *
+ * These tests verify mapPromise's behaviour with both the old pattern (eager
+ * promises) and the new pattern (lazy factory), and verify the retry logic,
+ * without needing any network access or domain-specific mocks.
+ */
+
+import { mapPromise } from '../../src/utils/map_promise';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Returns a timer-free promise that yields to the event loop once. */
+const tick = () => new Promise<void>(resolve => setImmediate(resolve));
+
+// ─── mapPromise concurrency tests ─────────────────────────────────────────────
+
+describe('mapPromise — concurrency limiting', () => {
+
+    it('OLD pattern: eager promises ignore requestConcurrency — all run at once', async () => {
+        // This test documents the *pre-fix* behaviour so the regression is
+        // explicit: even with concurrency: 1, all promises were already running.
+        const N = 10;
+        let activeCalls = 0;
+        let maxActiveCalls = 0;
+
+        // Eagerly start all promises (the old pattern in getReceiptProof).
+        const eagerPromises = Array.from({ length: N }, () => {
+            activeCalls++;
+            maxActiveCalls = Math.max(maxActiveCalls, activeCalls);
+            return tick().then(() => { activeCalls--; return 'ok'; });
+        });
+
+        // Pass the already-running promises with concurrency: 1.
+        // The identity converter (val => val) just returns the promise.
+        await mapPromise(eagerPromises, (val: Promise<string>) => val, { concurrency: 1 });
+
+        // All N started before mapPromise was called — concurrency was not limited.
+        expect(maxActiveCalls).toBe(N);
+    });
+
+    it('NEW pattern: lazy factory respects requestConcurrency', async () => {
+        const N = 20;
+        const LIMIT = 5;
+        let activeCalls = 0;
+        let maxActiveCalls = 0;
+
+        const values = Array.from({ length: N }, (_, i) => i);
+
+        // Pass hashes (values), not pre-started promises.
+        // The converter is the factory: it starts the request.
+        await mapPromise(values, async (_val: number) => {
+            activeCalls++;
+            maxActiveCalls = Math.max(maxActiveCalls, activeCalls);
+            await tick();
+            activeCalls--;
+            return 'ok';
+        }, { concurrency: LIMIT });
+
+        expect(maxActiveCalls).toBeLessThanOrEqual(LIMIT);
+        // Sanity: all items were processed.
+        expect(maxActiveCalls).toBeGreaterThan(0);
+    });
+
+    it('without a concurrency limit all N factory calls run concurrently', async () => {
+        const N = 20;
+        let activeCalls = 0;
+        let maxActiveCalls = 0;
+
+        const values = Array.from({ length: N }, (_, i) => i);
+
+        await mapPromise(values, async (_val: number) => {
+            activeCalls++;
+            maxActiveCalls = Math.max(maxActiveCalls, activeCalls);
+            await tick();
+            activeCalls--;
+            return 'ok';
+        }); // no concurrency option → default is N
+
+        expect(maxActiveCalls).toBe(N);
+    });
+
+});
+
+// ─── Retry-on-transient-error tests ───────────────────────────────────────────
+
+describe('getReceiptProof retry logic', () => {
+
+    /**
+     * Replicates the retry closure used in the fixed getReceiptProof converter,
+     * including the full-jitter backoff, so the tests verify the exact pattern
+     * that is shipped.
+     */
+    const MAX_RETRIES = 2;
+    function withRetry<T>(fn: () => Promise<T>, remaining = MAX_RETRIES): Promise<T> {
+        return fn().catch((err: any) => {
+            const isTransient =
+                err?.code === 'ECONNRESET'   ||
+                err?.code === 'ENOTFOUND'    ||
+                err?.code === 'ECONNREFUSED' ||
+                err?.code === 'ETIMEDOUT'    ||
+                err?.errno === 'ECONNRESET'  ||
+                err?.errno === 'ENOTFOUND';
+            if (remaining > 0 && isTransient) {
+                const i = MAX_RETRIES - remaining;
+                const delayMs = Math.random() * Math.min(250, 50 * Math.pow(2, i));
+                return new Promise<void>(resolve => setTimeout(resolve, delayMs))
+                    .then(() => withRetry(fn, remaining - 1));
+            }
+            throw err;
+        });
+    }
+
+    it('succeeds on the second attempt after one ECONNRESET', async () => {
+        let calls = 0;
+        const result = await withRetry(() => {
+            calls++;
+            if (calls === 1) return Promise.reject(Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' }));
+            return Promise.resolve('ok');
+        });
+        expect(result).toBe('ok');
+        expect(calls).toBe(2);
+    });
+
+    it('succeeds on the second attempt after one ENOTFOUND', async () => {
+        let calls = 0;
+        const result = await withRetry(() => {
+            calls++;
+            if (calls === 1) return Promise.reject(Object.assign(new Error('getaddrinfo ENOTFOUND'), { code: 'ENOTFOUND' }));
+            return Promise.resolve('ok');
+        });
+        expect(result).toBe('ok');
+        expect(calls).toBe(2);
+    });
+
+    it('exhausts all 2 retries (3 total calls) and then throws', async () => {
+        let calls = 0;
+        await expect(withRetry(() => {
+            calls++;
+            return Promise.reject(Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' }));
+        })).rejects.toMatchObject({ code: 'ECONNRESET' });
+        expect(calls).toBe(3); // 1 initial + 2 retries
+    });
+
+    it('does NOT retry a non-transient error', async () => {
+        let calls = 0;
+        await expect(withRetry(() => {
+            calls++;
+            return Promise.reject(Object.assign(new Error('execution reverted'), { code: 'CALL_EXCEPTION' }));
+        })).rejects.toMatchObject({ code: 'CALL_EXCEPTION' });
+        expect(calls).toBe(1); // no retries
+    });
+
+});


### PR DESCRIPTION
## Problem

`ProofUtil.getReceiptProof` has two related bugs that combine to make proof generation intermittently fail on mainnet blocks.

### Bug 1 — `requestConcurrency` has no effect on HTTP concurrency

The original code called `web3.getTransactionReceipt()` inside a `forEach` loop and collected the **already-running** Promises into an array, then passed that array to `mapPromise`:

```ts
// Before (broken)
const receiptPromises = [];
block.transactions.forEach(tx => {
    receiptPromises.push(
        web3.getTransactionReceipt(tx.transactionHash)  // request starts HERE
    );
});
receiptPromise = mapPromise(receiptPromises, val => val, { concurrency: requestConcurrency });
//                          ^^^^^^^^^^^^^^^^ all already in-flight
```

Because all requests were in-flight before `mapPromise` was called, the `concurrency` option only controlled *result-batching* — it had zero effect on how many HTTP requests ran simultaneously. On Polygon mainnet a block can contain 280+ transactions, so all receipts were always fetched in a single uncontrolled burst regardless of any `requestConcurrency` setting passed by the caller.

### Bug 2 — Transient network errors are not retried

Node.js 19+ [changed the default `https.globalAgent`](https://nodejs.org/en/blog/announcements/v19-release-announce#httpsrequests-now-keep-alive-by-default) to `keepAlive: true`. ethers.js v5 does not pass a custom agent to `https.request`, so it uses the global agent.

The proof-generation flow makes several Polygon RPC calls early (isCheckPointed, getBlockWithTransaction, getFastMerkleProof's O(log N) sequential calls), then idles for a few seconds during sequential Ethereum calls (getRootBlockInfo). During that idle window the RPC server can close pooled keep-alive connections. When `getReceiptProof` then fires all 280+ requests, some reuse stale sockets and receive `ECONNRESET`. Because neither `mapPromise` nor the converter had any retry logic, a single transient failure propagated immediately through `Promise.all` and the entire proof attempt failed.

The same issue causes intermittent `ENOTFOUND` errors — when many new connections must be established simultaneously (because all pooled ones are stale), the burst of concurrent DNS lookups can fail transiently.

## Fix

Collect tx hashes without starting requests, then pass a **factory function** to `mapPromise` so requests start lazily under `mapPromise`'s concurrency control. Wrap each call with up to 2 retries for the transient error codes, with a full-jitter exponential backoff delay of `[0, min(250ms, 50ms × 2ⁱ)]` before each retry — so that a burst of simultaneous failures does not hammer the RPC endpoint with synchronised retries:

```ts
// After (fixed)
const txHashes: string[] = [];
block.transactions.forEach(tx => {
    if (tx.transactionHash === stateSyncTxHash) return;
    txHashes.push(tx.transactionHash);  // collect hashes, don't start requests
});
const MAX_RETRIES = 2;
receiptPromise = mapPromise(
    txHashes,
    (hash: string) => {
        const attempt = (remaining: number): Promise<ITransactionReceipt> =>
            web3.getTransactionReceipt(hash).catch((err: any) => {
                const isTransient =
                    err?.code === 'ECONNRESET'   ||
                    err?.code === 'ENOTFOUND'    ||
                    err?.code === 'ECONNREFUSED' ||
                    err?.code === 'ETIMEDOUT'    ||
                    err?.errno === 'ECONNRESET'  ||
                    err?.errno === 'ENOTFOUND';
                if (remaining > 0 && isTransient) {
                    const i = MAX_RETRIES - remaining;
                    const delayMs = Math.random() * Math.min(250, 50 * Math.pow(2, i));
                    return new Promise<void>(resolve => setTimeout(resolve, delayMs))
                        .then(() => attempt(remaining - 1));
                }
                throw err;
            });
        return attempt(MAX_RETRIES);
    },
    { concurrency: requestConcurrency }
);
```

Retry delays: first retry `[0, 50ms]`, second retry `[0, 100ms]`.

With this change, setting `requestConcurrency: 10` in a caller actually limits concurrent HTTP connections to 10, which also reduces the probability of stale-socket hits by spacing out connection creation.

## Tests

Seven unit tests are added in `test/specs/index.ts`. They run without any network access:

- **`OLD pattern: eager promises ignore requestConcurrency`** — documents the pre-fix behaviour as a regression guard: even with `concurrency: 1`, all N promises fired simultaneously because they were pre-started.
- **`NEW pattern: lazy factory respects requestConcurrency`** — proves the fix: with a factory converter and `concurrency: 5`, never more than 5 calls are active at once.
- **`without a concurrency limit all N factory calls run concurrently`** — baseline check that the default (unlimited) behaviour is preserved.
- **`succeeds on the second attempt after one ECONNRESET`**
- **`succeeds on the second attempt after one ENOTFOUND`**
- **`exhausts all 2 retries (3 total calls) and then throws`**
- **`does NOT retry a non-transient error`**

Run with:
```
cd test && npm test
```