### PR TITLE
Release v3.9.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maticnetwork/maticjs",
-  "version": "3.9.6",
+  "version": "3.9.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@maticnetwork/maticjs",
-      "version": "3.9.6",
+      "version": "3.9.7",
       "license": "MIT",
       "dependencies": {
         "@ethereumjs/block": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maticnetwork/maticjs",
-  "version": "3.9.6",
+  "version": "3.9.7",
   "description": "Javascript developer library for interacting with Matic Network",
   "main": "dist/npm.export.js",
   "types": "dist/ts/index.d.ts",


### PR DESCRIPTION
Bump version to 3.9.7.

Includes the fix from #460 (`fix(proof_util): make requestConcurrency effective and retry transient errors`).